### PR TITLE
Adding support for using generic entityreference field handler.

### DIFF
--- a/er_plus.migrate.inc
+++ b/er_plus.migrate.inc
@@ -25,7 +25,10 @@ class MigrateERPlusFieldHandler extends MigrateEntityReferenceFieldHandler {
   }
 
   public function prepare($entity, array $field_info, array $instance, array $values) {
-    parent::prepare($entity, $field_info, $instance, $values);
+    $parent_return = parent::prepare($entity, $field_info, $instance, $values);
+    if (isset($values['arguments']) && $values['arguments']['file_class'] == 'MigrateEntityReferenceFieldHandler') {
+      return $parent_return;
+    }
     $items = array();
     foreach ($values as $delta => $item_id) {
       if (is_int($delta) && is_array($item_id)) {
@@ -64,6 +67,7 @@ class MigrateERPlusFieldHandler extends MigrateEntityReferenceFieldHandler {
     $fields = array();
     $fields['view_mode'] = t('Subfield: View mode for the field');
     $fields['header'] = t('Subfield: Header for the field');
+    $fields['file_class'] = t('Subfield: Class to use. Currently, only MigrateEntityReferenceFieldHandler is supported as an option.');
     return $fields;
   }
 

--- a/er_plus.migrate.inc
+++ b/er_plus.migrate.inc
@@ -26,7 +26,7 @@ class MigrateERPlusFieldHandler extends MigrateEntityReferenceFieldHandler {
 
   public function prepare($entity, array $field_info, array $instance, array $values) {
     $parent_return = parent::prepare($entity, $field_info, $instance, $values);
-    if (isset($values['arguments']) && $values['arguments']['file_class'] == 'MigrateEntityReferenceFieldHandler') {
+    if (isset($values['arguments']['file_class']) && $values['arguments']['file_class'] == 'MigrateEntityReferenceFieldHandler') {
       return $parent_return;
     }
     $items = array();

--- a/er_plus.migrate.inc
+++ b/er_plus.migrate.inc
@@ -26,7 +26,7 @@ class MigrateERPlusFieldHandler extends MigrateEntityReferenceFieldHandler {
 
   public function prepare($entity, array $field_info, array $instance, array $values) {
     $parent_return = parent::prepare($entity, $field_info, $instance, $values);
-    if (isset($values['arguments']['file_class']) && $values['arguments']['file_class'] == 'MigrateEntityReferenceFieldHandler') {
+    if (isset($values['arguments']['class']) && $values['arguments']['class'] == 'MigrateEntityReferenceFieldHandler') {
       return $parent_return;
     }
     $items = array();
@@ -67,7 +67,7 @@ class MigrateERPlusFieldHandler extends MigrateEntityReferenceFieldHandler {
     $fields = array();
     $fields['view_mode'] = t('Subfield: View mode for the field');
     $fields['header'] = t('Subfield: Header for the field');
-    $fields['file_class'] = t('Subfield: Class to use. Currently, only MigrateEntityReferenceFieldHandler is supported as an option.');
+    $fields['class'] = t('Subfield: Class to use. Currently, only MigrateEntityReferenceFieldHandler is supported as an option.');
     return $fields;
   }
 


### PR DESCRIPTION
@bleeDev I had both an er_plus field and a regular entityreference field on a single content type, so needed to be able to use both field handlers. This adds that support, without needing to enable the regular entityreference migrate field handler.

Example usage:

``` php
$this->addFieldMapping('field_regular_entityreference:class')
  ->defaultValue('MigrateEntityReferenceFieldHandler');
```
